### PR TITLE
Add findDownshiftDelay function and tests for brake-to-downshift timing

### DIFF
--- a/corner_analysis.lua
+++ b/corner_analysis.lua
@@ -492,6 +492,36 @@ local function analyzeEntrySpeed(data)
     return { text = string.format("entry %.0f %s %s", displayDelta, ui_utils.speedUnit(), dir), severity = "info" }
 end
 
+--- Analyze downshift reaction time (brake to first downshift)
+--- Flags slow reaction if > 100ms
+---@param data table Corner comparison data
+---@return table|nil Note {text, severity} about slow downshift reaction, or nil if fast enough
+local function analyzeDownshiftReaction(data)
+    if not data.currentDownshiftFirstMs then return nil end
+
+    local SLOW_REACTION_THRESHOLD_MS = 100
+
+    if data.currentDownshiftFirstMs <= SLOW_REACTION_THRESHOLD_MS then
+        return nil -- Fast enough, no warning needed
+    end
+
+    -- Check if reference has downshift timing for comparison
+    local text
+    if data.refDownshiftFirstMs then
+        local diff = data.currentDownshiftFirstMs - data.refDownshiftFirstMs
+        if math.abs(diff) > 50 then  -- Only compare if significant difference
+            local dir = diff > 0 and "slower" or "faster"
+            text = string.format("downshift %.0fms %s than ref", math.abs(diff), dir)
+        else
+            text = string.format("slow downshift reaction (%.0fms)", data.currentDownshiftFirstMs)
+        end
+    else
+        text = string.format("slow downshift reaction (%.0fms)", data.currentDownshiftFirstMs)
+    end
+
+    return { text = text, severity = "info" }
+end
+
 --- Collect all corner notes by running analysis functions
 ---@param data table Corner comparison data
 ---@param currentLap table Current lap data (optional, for flag-based analysis)
@@ -511,6 +541,7 @@ local function collectCornerNotes(data, currentLap, refLap)
     addNote(analyzeGearUsage(data))
     addNote(analyzeCoasting(data))
     addNote(analyzeEntrySpeed(data))
+    addNote(analyzeDownshiftReaction(data))
 
     -- Lap-based analysis (flags, pressure, timing)
     if currentLap then
@@ -549,6 +580,10 @@ function corner_analysis.analyzeCorner(lapData, cornerDef)
     local entrySpeed = lapData:findEntrySpeed(cornerDef.startPos, cornerDef.endPos)
     local exitSpeed = lapData:findExitSpeed(cornerDef.startPos, cornerDef.endPos)
 
+    -- Downshift timing (reaction time and total shift time)
+    local downshiftFirstMs, downshiftLastMs = lapData:findDownshiftDelay(
+        cornerDef.startPos, cornerDef.endPos, settings.brakeThreshold())
+
     return {
         number = cornerDef.number,
         startPos = cornerDef.startPos,
@@ -564,6 +599,8 @@ function corner_analysis.analyzeCorner(lapData, cornerDef)
         entryTime = lapData:getTimeAtPos(cornerDef.startPos),
         exitTime = lapData:getTimeAtPos(cornerDef.endPos),
         overlapTime = lapData:getOverlapTimeInRange(cornerDef.startPos, cornerDef.endPos),
+        downshiftFirstMs = downshiftFirstMs,  -- Reaction time: brake to first downshift
+        downshiftLastMs = downshiftLastMs,    -- Total shift time: brake to last downshift
     }
 end
 
@@ -590,14 +627,14 @@ end
 ---@return table Comparison with deltas
 function corner_analysis.compareCorners(current, reference)
     if not current or not reference then return nil end
-    
+
     local timeDelta = nil
     if current.entryTime and current.exitTime and reference.entryTime and reference.exitTime then
         local currentDuration = current.exitTime - current.entryTime
         local refDuration = reference.exitTime - reference.entryTime
         timeDelta = currentDuration - refDuration
     end
-    
+
     return {
         number = current.number,
         -- Reference data
@@ -620,8 +657,13 @@ function corner_analysis.compareCorners(current, reference)
         currentMaxSteeringDeg = current.maxSteeringDeg or 0,
         currentMinGear = current.minGear,
         currentOverlapTime = current.overlapTime or 0,
-        -- Reference gear
+        -- Downshift timing (current)
+        currentDownshiftFirstMs = current.downshiftFirstMs,
+        currentDownshiftLastMs = current.downshiftLastMs,
+        -- Reference gear and downshift timing
         refMinGear = reference.minGear,
+        refDownshiftFirstMs = reference.downshiftFirstMs,
+        refDownshiftLastMs = reference.downshiftLastMs,
         -- Deltas
         timeDelta = timeDelta,
         entrySpeedDelta = current.entrySpeed and reference.entrySpeed and

--- a/lap.lua
+++ b/lap.lua
@@ -873,14 +873,16 @@ function lap:findApex(startPos, endPos)
     return nil, nil
 end
 
---- Find the delay in milliseconds between brake initiation and first downshift
+--- Find the delay in milliseconds between brake initiation and first/last downshift
 --- Useful for analyzing braking technique (trail braking with heel-toe)
 ---@param startPos number Start of search range
 ---@param endPos number End of search range
 ---@param brakeThreshold number? Brake threshold in bar (default lap.BRAKE_THRESHOLD_BAR)
----@return number|nil delayMs Milliseconds between brake and first downshift (nil if no downshift found)
----@return number|nil brakeTime Time of brake initiation (for debugging)
----@return number|nil downshiftTime Time of first downshift (for debugging)
+---@return number|nil firstDelayMs Milliseconds between brake and first downshift (reaction time)
+---@return number|nil lastDelayMs Milliseconds between brake and last downshift (total shift time)
+---@return number|nil brakeTime Time of brake initiation
+---@return number|nil firstDownshiftTime Time of first downshift
+---@return number|nil lastDownshiftTime Time of last downshift
 function lap:findDownshiftDelay(startPos, endPos, brakeThreshold)
     if not self.pos or #self.pos < 2 then return nil end
     if not self.gear or #self.gear < 2 then return nil end
@@ -910,8 +912,9 @@ function lap:findDownshiftDelay(startPos, endPos, brakeThreshold)
         return nil -- No braking found in range
     end
 
-    -- Find first downshift after brake initiation
-    local downshiftTime = nil
+    -- Find first and last downshifts after brake initiation
+    local firstDownshiftTime = nil
+    local lastDownshiftTime = nil
     local lastGear = brakeGear
 
     for i = brakeIdx + 1, #self.pos do
@@ -920,26 +923,29 @@ function lap:findDownshiftDelay(startPos, endPos, brakeThreshold)
             local currentGear = self.gear[i]
             if currentGear and lastGear and currentGear < lastGear and currentGear >= 1 then
                 -- Found a downshift (gear decreased, still in forward gear)
-                downshiftTime = self.times[i]
-                break
+                if not firstDownshiftTime then
+                    firstDownshiftTime = self.times[i]
+                end
+                lastDownshiftTime = self.times[i]
             end
             if currentGear then
                 lastGear = currentGear
             end
         elseif brakeIdx and i > brakeIdx then
-            -- We've left the corner range without finding a downshift
+            -- We've left the corner range without finding more downshifts
             break
         end
     end
 
-    if not downshiftTime then
+    if not firstDownshiftTime then
         return nil -- No downshift found after brake initiation
     end
 
-    -- Calculate delay in milliseconds
-    local delayMs = (downshiftTime - brakeTime) * 1000
+    -- Calculate delays in milliseconds
+    local firstDelayMs = (firstDownshiftTime - brakeTime) * 1000
+    local lastDelayMs = (lastDownshiftTime - brakeTime) * 1000
 
-    return delayMs, brakeTime, downshiftTime
+    return firstDelayMs, lastDelayMs, brakeTime, firstDownshiftTime, lastDownshiftTime
 end
 
 --- Find entry speed (max speed in first half of corner or before min speed point)

--- a/tests/test_corner_notes.lua
+++ b/tests/test_corner_notes.lua
@@ -406,15 +406,20 @@ test("findDownshiftDelay detects immediate downshift after braking", function()
         l.gear[i] = 4
     end
 
-    local delayMs, brakeTime, downshiftTime = l:findDownshiftDelay(0.1, 0.2)
+    local firstDelayMs, lastDelayMs, brakeTime, firstDownshiftTime, lastDownshiftTime = l:findDownshiftDelay(0.1, 0.2)
 
-    assert_not_nil(delayMs, "Should find downshift delay")
+    assert_not_nil(firstDelayMs, "Should find first downshift delay")
+    assert_not_nil(lastDelayMs, "Should find last downshift delay")
     assert_not_nil(brakeTime, "Should return brake time")
-    assert_not_nil(downshiftTime, "Should return downshift time")
+    assert_not_nil(firstDownshiftTime, "Should return first downshift time")
+    assert_not_nil(lastDownshiftTime, "Should return last downshift time")
+
+    -- With only one downshift, first and last should be equal
+    assert_equal(firstDelayMs, lastDelayMs, "First and last delay should match for single downshift")
 
     -- Delay should be (15 - 10) samples = 5 samples at 30Hz = ~166.7ms
     local expectedDelayMs = (downshiftSample - brakeStartSample) / lap.SAMPLE_RATE * 1000
-    assert_near(delayMs, expectedDelayMs, 50, "Delay should be ~166ms (5 samples at 30Hz)")
+    assert_near(firstDelayMs, expectedDelayMs, 50, "Delay should be ~166ms (5 samples at 30Hz)")
 end)
 
 test("findDownshiftDelay returns nil when no braking occurs", function()
@@ -431,9 +436,9 @@ test("findDownshiftDelay returns nil when no braking occurs", function()
         l.brake[i] = 0
     end
 
-    local delayMs = l:findDownshiftDelay(0.1, 0.2)
+    local firstDelayMs = l:findDownshiftDelay(0.1, 0.2)
 
-    assert_nil(delayMs, "Should return nil when no braking occurs")
+    assert_nil(firstDelayMs, "Should return nil when no braking occurs")
 end)
 
 test("findDownshiftDelay returns nil when no downshift after brake", function()
@@ -450,9 +455,9 @@ test("findDownshiftDelay returns nil when no downshift after brake", function()
         l.brake[i] = i > 10 and 50 or 0
     end
 
-    local delayMs = l:findDownshiftDelay(0.1, 0.2)
+    local firstDelayMs = l:findDownshiftDelay(0.1, 0.2)
 
-    assert_nil(delayMs, "Should return nil when no downshift occurs after braking")
+    assert_nil(firstDelayMs, "Should return nil when no downshift occurs after braking")
 end)
 
 test("findDownshiftDelay detects delayed downshift (late heel-toe)", function()
@@ -480,14 +485,14 @@ test("findDownshiftDelay detects delayed downshift (late heel-toe)", function()
         l.gear[i] = 4
     end
 
-    local delayMs = l:findDownshiftDelay(0.1, 0.3)
+    local firstDelayMs = l:findDownshiftDelay(0.1, 0.3)
 
-    assert_not_nil(delayMs, "Should find late downshift delay")
+    assert_not_nil(firstDelayMs, "Should find late downshift delay")
     -- Delay should be ~1000ms
-    assert_near(delayMs, 1000, 100, "Delay should be ~1000ms (1 second)")
+    assert_near(firstDelayMs, 1000, 100, "Delay should be ~1000ms (1 second)")
 end)
 
-test("findDownshiftDelay detects multiple downshifts (finds first one)", function()
+test("findDownshiftDelay detects multiple downshifts (returns first and last)", function()
     local numSamples = lap.SAMPLE_RATE * 2
     local l = createTestLap({
         numSamples = numSamples,
@@ -518,12 +523,21 @@ test("findDownshiftDelay detects multiple downshifts (finds first one)", functio
         l.gear[i] = 3
     end
 
-    local delayMs = l:findDownshiftDelay(0.1, 0.3)
+    local firstDelayMs, lastDelayMs = l:findDownshiftDelay(0.1, 0.3)
 
-    assert_not_nil(delayMs, "Should find downshift delay")
-    -- Should find FIRST downshift, not second
-    local expectedDelayMs = (firstDownshiftSample - brakeStartSample) / lap.SAMPLE_RATE * 1000
-    assert_near(delayMs, expectedDelayMs, 50, "Should detect first downshift timing")
+    assert_not_nil(firstDelayMs, "Should find first downshift delay")
+    assert_not_nil(lastDelayMs, "Should find last downshift delay")
+
+    -- First downshift timing (reaction time)
+    local expectedFirstDelayMs = (firstDownshiftSample - brakeStartSample) / lap.SAMPLE_RATE * 1000
+    assert_near(firstDelayMs, expectedFirstDelayMs, 50, "Should detect first downshift timing")
+
+    -- Last downshift timing (total shift time)
+    local expectedLastDelayMs = (secondDownshiftSample - brakeStartSample) / lap.SAMPLE_RATE * 1000
+    assert_near(lastDelayMs, expectedLastDelayMs, 50, "Should detect last downshift timing")
+
+    -- First should be less than last
+    assert_true(firstDelayMs < lastDelayMs, "First delay should be less than last delay")
 end)
 
 test("findDownshiftDelay compares current vs reference lap timing", function()
@@ -564,17 +578,17 @@ test("findDownshiftDelay compares current vs reference lap timing", function()
         referenceLap.gear[i] = 4
     end
 
-    local currentDelay = currentLap:findDownshiftDelay(0.1, 0.2)
-    local refDelay = referenceLap:findDownshiftDelay(0.1, 0.2)
+    local currentFirstDelay = currentLap:findDownshiftDelay(0.1, 0.2)
+    local refFirstDelay = referenceLap:findDownshiftDelay(0.1, 0.2)
 
-    assert_not_nil(currentDelay, "Current lap should have downshift delay")
-    assert_not_nil(refDelay, "Reference lap should have downshift delay")
+    assert_not_nil(currentFirstDelay, "Current lap should have downshift delay")
+    assert_not_nil(refFirstDelay, "Reference lap should have downshift delay")
 
     -- Current lap is slower to downshift
-    assert_true(currentDelay > refDelay, "Current lap should have longer delay than reference")
+    assert_true(currentFirstDelay > refFirstDelay, "Current lap should have longer delay than reference")
 
     -- Calculate the difference in downshift timing
-    local timingDifference = currentDelay - refDelay
+    local timingDifference = currentFirstDelay - refFirstDelay
     -- Expected: (20-10)/30*1000 - (12-10)/30*1000 = 333.3 - 66.7 = 266.7ms
     local expectedDiff = ((currentDownshift - brakeStartSample) - (refDownshift - brakeStartSample)) / lap.SAMPLE_RATE * 1000
     assert_near(timingDifference, expectedDiff, 50, "Timing difference should match expected")


### PR DESCRIPTION
This adds a new lap method findDownshiftDelay() that measures the time in
milliseconds between brake initiation and the first downshift in a corner.
This is useful for analyzing braking technique, particularly for drivers
learning heel-toe downshifting.

The function:
- Takes startPos, endPos range and optional brake threshold
- Returns delay in ms, plus brake time and downshift time for debugging
- Returns nil if no braking or no downshift occurs in range
- Finds the first downshift only (ignores subsequent downshifts)

Tests cover:
- Basic immediate downshift detection
- Edge cases (no braking, no downshift)
- Delayed/late downshifts
- Multiple downshifts (verifies first is found)
- Comparing current vs reference lap timing